### PR TITLE
Add font awesome script in correct place

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,5 @@
 <footer class="site-footer h-card">
-    <script src='https://kit.fontawesome.com/a076d05399.js' crossorigin='anonymous'></script>
-
+    
     <data class="u-url" href="{{ "/" | relative_url }}"></data>
 
     <div class="wrapper">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,13 @@
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    {%- seo -%}
+    <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
+    {% comment %} The below is to import the envelope icon. {% endcomment %}
+    <script src='https://kit.fontawesome.com/a076d05399.js' crossorigin='anonymous'></script>
+    {%- feed_meta -%}
+    {%- if jekyll.environment == 'production' and site.google_analytics -%}
+      {%- include google-analytics.html -%}
+    {%- endif -%}
+  </head>

--- a/_includes/social.html
+++ b/_includes/social.html
@@ -1,5 +1,3 @@
-<script src='https://kit.fontawesome.com/a076d05399.js' crossorigin='anonymous'></script>
-
 {%- assign separator = " | " -%}
 
 <span class="social-media-list">


### PR DESCRIPTION
After deploying to production, the envelope icon began to disappear. [This](https://talk.jekyllrb.com/t/using-font-awesome/5267/3) tells me I need to add the font awesome script to the `head.html` file.