### PR TITLE
Unbreakable stack positions for job positions

### DIFF
--- a/assets/resume.js
+++ b/assets/resume.js
@@ -218,9 +218,10 @@ $(document).ready(function() {
               });
               let bulletPoints = list(ulArray);
 
-              for (let part of [title, bulletPoints]) {
-                positionsStack.push(part);
-              }
+              positionsStack.push({
+                stack: [title, bulletPoints],
+                unbreakable: true,
+              });
             });
 
             content.push({ stack: positionsStack, style: 'positions_stack' });

--- a/run_server.sh
+++ b/run_server.sh
@@ -6,6 +6,11 @@
 # https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll
 #
 # Optional: Add environment variable `JEKYLL_ENV=foobarbaz` to change the env.
+#
+# If running in GitHub Codespaces, downgrade to Ruby 2.7 first.
+#   rvm install ruby-2.7.2
+#   rvm use 2.7
+#
 
 set -euo pipefail
 


### PR DESCRIPTION
Make each position an unbreakable stack. This way positions won't be broken awkwardly over multiple pages.

### Before
[resume_2024_9_20 (2).pdf](https://github.com/user-attachments/files/17550527/resume_2024_9_20.2.pdf)
![Screenshot 2024-10-28 at 21 47 12](https://github.com/user-attachments/assets/abd8b293-94c8-459e-9450-530db780fc7d)


### After
[resume_2024_10_28 (1).pdf](https://github.com/user-attachments/files/17550525/resume_2024_10_28.1.pdf)
